### PR TITLE
FIX ortographe du mot deustchland -> deutschland

### DIFF
--- a/24-09-05.md
+++ b/24-09-05.md
@@ -55,7 +55,7 @@ Zoo: "tsso" // Zebra: "tssébra"
 1. Glaz : Es liegt in österreich (ça se situe en Autriche)
 2. Hamburg : Es liegt in Norddeutschland
 3. Bern : Es liegt in der Schweiz (ça se situe en Suisse)
-4. Berlin : Es liegt in Deustchland / die Haupstadt von Deutschland (la capitale de l'allemagne)
+4. Berlin : Es liegt in Deutschland / die Haupstadt von Deutschland (la capitale de l'allemagne)
 5. Frankfurt : Es liegt in Deutschland
 6. Wien : Es liegt in Österreich / die Hauptstadt von Österreich
 7. Genf : Es liegt in der Schweiz


### PR DESCRIPTION
ça s'écrit deutschland et pas deustchland, j'ai changé le mot l.58 

_4. Berlin : Es liegt in **Deutschland** / die Haupstadt von Deutschland (la capitale de l'allemagne)_
